### PR TITLE
Added support of existing security groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+This fork adds support for existing security groups. That is, port security will not be disabled. Use the ``--use-sg`` command line argument. If you specify only this, the project's default security group will be used, or you can specify any of the existing groups after the ``--use-sg`` parameter. You can also specify a security group in the configuration file. Specifying multiple security groups is not provided.
+
+----
+
 NFVbench: A Network Performance Benchmarking Tool for NFVi Full Stacks
 **********************************************************************
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # docker file for creating a container that has nfvbench installed and ready to use
 FROM ubuntu:20.04
 
-ENV TREX_VER "v2.89"
-ENV VM_IMAGE_VER "0.15"
+ENV TREX_VER "v3.04"
+ENV VM_IMAGE_VER "0.16"
 ENV PYTHONIOENCODING "utf8"
 
 RUN apt-get update && apt-get install -y \

--- a/nfvbench/cfg.default.yaml
+++ b/nfvbench/cfg.default.yaml
@@ -951,3 +951,9 @@ no_e2e_check: false
 # Designed for development needs
 # The hexadecimal notation (0x...) is accepted.
 debug_mask: 0x00000000
+
+# Do not disable port security
+# Use the default security group using the command line argument, or specify a single security group as in the following example
+# Example:
+# security_group: any_group
+# THIS PARAMETER MUST NOT BE EMPTY otherwise it must be commented out

--- a/nfvbench/nfvbench.py
+++ b/nfvbench/nfvbench.py
@@ -444,6 +444,14 @@ def _parse_opts_from_cli():
                         action='store_true',
                         help='Enable MPLS encapsulation')
 
+    parser.add_argument('--use-sg', dest='use_sg',
+                        action='store',
+                        const='',
+                        nargs='?',
+                        metavar='<security group name>',
+                        help='Do not disable port security and specify single security group. ' 
+                             'If left empty, the default security group will be used.')
+
     parser.add_argument('--no-cleanup', dest='no_cleanup',
                         default=None,
                         action='store_true',
@@ -810,6 +818,8 @@ def main():
         if opts.debug_mask is not None:
             config.debug_mask = opts.debug_mask
             opts.debug_mask = None
+        if opts.use_sg is not None:
+            config.security_group = opts.use_sg
 
         # convert 'user_info' opt from json string to dictionnary
         # and merge the result with the current config dictionnary


### PR DESCRIPTION
In some specific cases, a few customers asked me not to disable the port security feature. They wanted to do this for comparison purposes, to see how much of an impact security groups can have on VNFs. Perhaps this will be useful to others as well. 

With this commit, you can use the default project security group or specify a specific one. Specifying multiple security groups is not provided. 